### PR TITLE
Updates needed in the workflow to accommodate recent EGA and cluster changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The python client authenticates via your user account, place a file called 'ega.
 }
 ``` 
 
-See the [EGA documentation](https://ega-archive.org/download/downloader-quickguide-APIv3) for more info.
+See the [EGA documentation](https://ega-archive.org/access/download/files/pyega3) for more info.
 
 #### Dropbox method
 

--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ rm -rf .nextflow*
 ```
 
 ## Legacy code
-A previous implementation was used that required BAM/ CRAM files downloaded from EGA to be converted to fastq in an endedness-specific manner (i.e. paired endedness detected and handled correctly). The previous workflow, in addition of using the pyega3 client to pull files directly from EGA, included also the Aspera dropbox method to download files from a 'dropbox' provided to you from EGA staff - this method is now deprecated. See release 1.0.0 for more information on the earlier version.
+A previous implementation was used that required BAM/ CRAM files downloaded from EGA to be converted to fastq in an endedness-specific manner (i.e. paired endedness detected and handled correctly). The previous workflow, in addition of using the pyega3 client to pull files directly from EGA, included also the Aspera dropbox method to download files from a 'dropbox' provided to you from EGA staff - this method is now deprecated. See release v1.0.0 for more information on the earlier version.
 

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ Clone this repository to the top directory. For Aspera dropbox, you'll need to c
 Then run:
 
 ```
-./ega_tools/main.nf -resume -fetchMode=pyclient
+./ega_downloader/main.nf -resume -fetchMode=pyclient
 ```
 
 ... to use the python client to fetch files, or:
 
 
 ```
-./ega_tools/main.nf -resume -fetchMode=aspera
+./ega_downloader/main.nf -resume -fetchMode=aspera
 ```
 
 ... to pull files from an Aspera dropbox.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,23 @@
 # Download EGA data and arrange for analysis
 
-This is a Nextflow workflow designed to download data for an EGA dataset and arrange in a form suitable for analysis, with raw FASTQ files and a metadata table. BAM/ CRAM files are converted to fastq in an endedness-specific manner (i.e. paired endedness is detected and handled correctly).
+This is a Nextflow workflow designed to download data for an EGA dataset and arrange in a form suitable for analysis, with raw FASTQ files and a metadata table. 
 
-There are two operating modes:
+The  workflow uses the [pyega3](https://github.com/EGA-archive/ega-download-client) client to pull files directly from EGA.
 
- * Use the [pyega3](https://github.com/EGA-archive/ega-download-client) client to pull files directly from EGA. This will only work for datasets without the older .gpg encryption, with all files using .cip.
- * Download files from a 'dropbox' provided to you from EGA staff. This is usually done where there are issues using the official client (this mode is currently deprecated).
-
-Note that there is no provision to use the old EGA Java client, which we have found difficult to use successfully.
-
-In both cases the idea is to make sure that the files available correspond to those stated in the dataset metadata, and to parallelise the download of those files.
 
 ## Prerequisites
 
- * [Nextflow](https://www.nextflow.io/) installed
- * Formal access to the datasets of interest in EGA
- * For the dropbox download method, Aspera access to the dataset of interest. EGA will give you a download.sh script containing username and password, and a 'secret' for decrypting the files.
+ * [Nextflow](https://www.nextflow.io/) installed. Tested with v24.04.3
+ * Formal access to the datasets of interest in [EGA](https://ega-archive.org/)
+ * SLURM cluster management and job scheduling system
+ * An account and access the Seqera Platform (optional)
 
 ## Setup
 
 ### Directory structure
 
  * Create a directory for the dataset (with appropriate access restrictions - this is controlled access data)
- * Create 'data', 'metadata' and 'credentials' subdirectories
+ * Create 'metadata' and 'credentials' subdirectories
 
 ### Set up authentication
 
@@ -34,89 +29,49 @@ The python client authenticates via your user account, place a file called 'ega.
 {
         "username": "me@foo.bar.uk",
         "password": "abc123",
-        "client_secret": "klj;lkj;lkajf;lkja;lkfjsa;lkfja;lkfja;lsfdkja;lfkja;slfkjas;flkja;flkjas;flkjas;lkj"
 }
 ``` 
 
 See the [EGA documentation](https://ega-archive.org/access/download/files/pyega3) for more info.
 
-#### Dropbox method
-
-The 'download.sh' script EGA provides will download all the data for a dataset using Aspera, but to a fairly unpredictable subdirectory location. So we just extract the authentication information:
-
-```
-#!/bin/bash
-
-#inits
-export ASPERA_SCP_PASS="abcdef";
-username="dbox1234"
-destination="`dirname $0`"
-parallel_downloads=8
-
-#overwrite default parameters?
-if [ ! -z $1 ]; then parallel_downloads="$1"; fi
-if [ ! -z $2 ]; then destination="$2"; fi
-
-
-#get small files in its most convenient way
-ascp --ignore-host-key -E "*.aes" -E "*.cip" -E "*.crypt" -E "download.sh" -d -QTl 100m ${username}@xfer.crg.eu: ${destination}/
-
-#get not small files in its most convenient way
-cat ${destination}/dbox_content | xargs -i --max-procs=$parallel_downloads bash -c "mkdir -p $destination/\`dirname {}\`; echo \"Downloading {}, please wait ...\"; ascp --ignore-host-key -k 1 --partial-file-suffix=PART -QTl 100m ${username}@xfer.crg.eu:{} ${destination}/{} >/dev/null 2>&1"
-``` 
-
-You'll also separately be given a 'secret'.
-
-Create an authentication file for each component dataset, at e.g. credentials/EGAD00011223344.txt:
-
-```
-user=dbox1234
-password=abcdef
-secret=;lkj;lkj;lkj;lkj;lkj;lkj;lkj;lkj;lkj;lkj;lkj;lkj
-```
-
-Make sure this file is readable only by yourself!
 
 ### Obtain metadata
 
-Download the metadata bundle from the EGA page for each dataset. You'll get a bundle containing 'delimited_maps' and 'xmls'. Place these directories under 'metadata':
+Download the metadata bundle from the EGA page for each dataset. You'll have the option to download a zipped in TSV, CSV and JSON. Donwload the CSV version, unzip it and  contents place the files under 'metadata':
 
 ```
 metadata
-    |- EGAD00011223344
-        |- delimited_maps
-        |- xmls
+    |- analyses.csv
+    |- analysis_sample.csv
+    |- ...
 ```
 
-We now have all the information we need to download and structure the raw data.
+We now have all the information we need to download the raw data and process the metadata.
 
 ## Run download pipeline
 
-Clone this repository to the top directory. For Aspera dropbox, you'll need to copy EGA's 'decryptor.jar' app into the bin/ directory of this repo (since I didn't think it appropriate to redistribute that file).
+Clone this repository to the top directory. 
 
 Then run:
 
 ```
-./ega_downloader/main.nf -resume -fetchMode=pyclient
+source envs.sh
+nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID
 ```
 
-... to use the python client to fetch files, or:
+or
 
 
 ```
-./ega_downloader/main.nf -resume -fetchMode=aspera
+nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID -with-tower
 ```
 
-... to pull files from an Aspera dropbox.
+... to leverage [Seqera Platform](https://docs.seqera.io/platform/24.1.1/getting-started/deployment-options) capabilities. You'll need to obtain a token and add it to `envs.sh`.
 
 The result will be:
 
- * A metadata summary at a location like metadata/EGAD00011223344/ EGAD00011223344.merged.csv
- * Encrypted downloads at e.g. data/EGAD00011223344/encrypted (dropbox method only)
- * Decrypted files at data/(library strategy)/EGAD00011223344
- * FASTQ-converted files at data/EGAD00011223344/(library strategy)/fastq
-
-If there are random failures you can resume by repeating the above command.
+ * A metadata summary at a location like work/..../ega_metadata/EGAD00011223344.merged.csv
+ * FASTQ files at data/.../ega_data/(EGAFxxxxx)/fastq
 
 
 ## Clean up
@@ -126,4 +81,7 @@ Nexflow leaves a few things lying around, so once the above has succeeded, remov
 ```
 rm -rf .nextflow* work
 ```
+
+## Legacy code
+A previous implementation was used in the past/ That required BAM/ CRAM files to be converted to fastq in an endedness-specific manner (i.e. paired endedness is detected and handled correctly). The previous workflow, in addition of using the [pyega3](https://github.com/EGA-archive/ega-download-client) client to pull files directly from EGA, included also the Aspera dropbox method to download files from a 'dropbox' provided to you from EGA staff. This method is now deprecated. See release 1.0.0 for more information on the earlier version.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID
 nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID -with-tower
 ```
 
-*Optional*
-to leverage the [Seqera Platform](https://docs.seqera.io/platform/24.1.1/getting-started/deployment-options) capabilities. You'll need to obtain a token and add it to `envs.sh`.
+to leverage the [Seqera Platform](https://docs.seqera.io/platform/24.1.1/getting-started/deployment-options) capabilities (optional). You'll need to obtain a token and add it to `envs.sh`.
 
 The result will be:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID
 nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID -with-tower
 ```
 
+*Optional*
 to leverage the [Seqera Platform](https://docs.seqera.io/platform/24.1.1/getting-started/deployment-options) capabilities. You'll need to obtain a token and add it to `envs.sh`.
 
 The result will be:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The  workflow uses the [pyega3](https://github.com/EGA-archive/ega-download-clie
 
 ## Prerequisites
 
- * [Nextflow](https://www.nextflow.io/) installed. Tested with v24.04.3
+ * [Nextflow](https://www.nextflow.io/) installed. Current version tested with nextflow 24.04.3
  * Formal access to the datasets of interest in [EGA](https://ega-archive.org/)
  * SLURM cluster management and job scheduling system
  * An account and access the Seqera Platform (optional)
@@ -37,7 +37,7 @@ See the [EGA documentation](https://ega-archive.org/access/download/files/pyega3
 
 ### Obtain metadata
 
-Download the metadata bundle from the EGA page for each dataset. You'll have the option to download a zipped in TSV, CSV and JSON. Donwload the CSV version, unzip it and  contents place the files under 'metadata':
+Download the metadata bundle from the EGA page for each dataset. You'll have the option to download a zipped file with metadata in TSV, CSV and JSON. Download the CSV version, unzip it and place the files under 'metadata':
 
 ```
 metadata
@@ -59,14 +59,14 @@ source envs.sh
 nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID
 ```
 
-or
+... or
 
 
 ```
 nextflow run main.nf -c nextflow.config --EGA_DATASET_ID $EGA_DATASET_ID -with-tower
 ```
 
-... to leverage [Seqera Platform](https://docs.seqera.io/platform/24.1.1/getting-started/deployment-options) capabilities. You'll need to obtain a token and add it to `envs.sh`.
+to leverage the [Seqera Platform](https://docs.seqera.io/platform/24.1.1/getting-started/deployment-options) capabilities. You'll need to obtain a token and add it to `envs.sh`.
 
 The result will be:
 
@@ -79,9 +79,9 @@ The result will be:
 Nexflow leaves a few things lying around, so once the above has succeeded, remove them:
 
 ```
-rm -rf .nextflow* work
+rm -rf .nextflow*
 ```
 
 ## Legacy code
-A previous implementation was used in the past/ That required BAM/ CRAM files to be converted to fastq in an endedness-specific manner (i.e. paired endedness is detected and handled correctly). The previous workflow, in addition of using the [pyega3](https://github.com/EGA-archive/ega-download-client) client to pull files directly from EGA, included also the Aspera dropbox method to download files from a 'dropbox' provided to you from EGA staff. This method is now deprecated. See release 1.0.0 for more information on the earlier version.
+A previous implementation was used that required BAM/ CRAM files downloaded from EGA to be converted to fastq in an endedness-specific manner (i.e. paired endedness detected and handled correctly). The previous workflow, in addition of using the pyega3 client to pull files directly from EGA, included also the Aspera dropbox method to download files from a 'dropbox' provided to you from EGA staff - this method is now deprecated. See release 1.0.0 for more information on the earlier version.
 

--- a/bin/arrange_data.R
+++ b/bin/arrange_data.R
@@ -195,21 +195,17 @@ study_experiment_run_sample <-  read.csv( paste0(opt$metadata_dir,'/study_experi
 
 matched_indices <- match(metadata$sample_alias, study_experiment_run_sample$sample_alias)
 
-metadata$biosample_id <- study_experiment_run_sample$biosample_id[matched_indices]
 metadata$ega_run_id <- study_experiment_run_sample$run_accession_id[matched_indices]
 metadata$ega_experiment_id <- study_experiment_run_sample$experiment_accession_id[matched_indices]
 
-metadata$library_strategy <- study_experiment_run_sample$library_strategy[matched_indices]
-metadata$library_source <- study_experiment_run_sample$library_source[matched_indices]
-metadata$library_layout <- study_experiment_run_sample$library_layout[matched_indices]
+columns_matched_indices <- c("biosample_id", 
+             "library_strategy", "library_source", "library_layout", 
+             "library_name", "library_selection", "study_title", 
+             "study_type", "instrument_platform", "instrument_model")
 
-metadata$library_name <- study_experiment_run_sample$library_name[matched_indices]
-metadata$library_selection <- study_experiment_run_sample$library_selection[matched_indices]
-metadata$study_title <- study_experiment_run_sample$study_title[matched_indices]
-metadata$study_type <- study_experiment_run_sample$study_type[matched_indices]
-metadata$instrument_platform <- study_experiment_run_sample$instrument_platform[matched_indices]
-metadata$instrument_model <- study_experiment_run_sample$instrument_model[matched_indices]
-
+for (col in columns_matched_indices) {
+    metadata[[col]] <- study_experiment_run_sample[[col]][matched_indices]
+}
 
 
 # 5 update metadata with information from experiments.csv

--- a/envs.sh
+++ b/envs.sh
@@ -1,0 +1,4 @@
+export EGA_DATASET_ID=EGAD00001011134
+export TOWER_ACCESS_TOKEN=
+export NXF_VER=24.04.3
+export CONDA_ENVS=path-to-conda-envs

--- a/main.nf
+++ b/main.nf
@@ -1,341 +1,52 @@
-#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
 
-dataDir = "${workflow.launchDir}/${params.dataDir}"
 metadataDir = "${workflow.launchDir}/${params.metadataDir}"
 egaCredentialsDir = "${workflow.launchDir}/${params.egaCredentialsDir}"
-fetchMode = params.fetchMode
 
-DATASETS = Channel.fromPath( "$dataDir/EGAD*", type: 'dir', checkIfExists: true )
-
-DATASETS.map{ dir -> tuple( file(dir).getName(), dir ) }
-    .set {KEYED_DATASETS}
-
-// aspera is to be deprecated, so we will use pyega3 to fetch the files
-if (fetchMode == 'aspera'){
-    process get_dbox_content {
-
-        cache 'lenient'
-        
-        input:
-            set val(dsId), file(dsPath) from KEYED_DATASETS
-
-        output:
-            set val(dsId), file('dbox_content') into AVAILABLE_FILES
-
-        """
-        credentialsFile=$egaCredentialsDir/${dsId}.txt
-        if [ ! -e \$credentialsFile ]; then
-            echo "Credentials file missing at \$credentialsFile" 1>&2
-            exit 1
-        fi
-
-        user=\$(grep "^user=" \$credentialsFile | sed s/user=//)
-        password=\$(grep "^password=" \$credentialsFile | sed s/password=//)
-        export ASPERA_SCP_PASS="\$password";   
-
-        ascp --ignore-host-key -d -QTl 100m \${user}@xfer.crg.eu:dbox_content \$(pwd)/
-        """
-    }
+workflow {
+    main:
+        fetch_data(params.EGA_DATASET_ID)
+        make_metadata_table(params.EGA_DATASET_ID)
 }
-else{
-    process get_ega_file_listing {
 
-        // This process is not strictly necessary, but it is useful to have a cached file listing.
-        // Current version pf pyega3 can be provided directly with the dataset ID (EGAD*) and this will
-        // directly download all relevant files without the need of storing them into a txt file
-        
-        cache 'lenient'
+process fetch_data {
 
-        conda 'pyega3>=5.2.0 python>=3.9.19'
+    conda 'pyega3=5.2.0'
 
-        input:
-            set val(dsId), file(dsPath) from KEYED_DATASETS
-        
-        output:
-            set val(dsId), file('pyega3_file_listing.txt') into AVAILABLE_FILES
+    cache 'lenient'
 
+    input:
+        val EGA_DATASET_ID
+
+    output:
+        file "ega_data/*"
+
+    script:
         """
-        pyega3 -d -cf $egaCredentialsDir/ega.credentials files $dsId | grep 'File ID\\|EGAF' | sed 's/File /File_/g' | sed 's/Check /Check_/' | sed -e "s/ \\+/\\t/g" > pyega3_file_listing.txt
+	    mkdir -p ega_data
+	    # list unencrypted md5 checksums for all files
+	    pyega3 -cf $egaCredentialsDir/ega.credentials files ${params.EGA_DATASET_ID}
+	    # download the dataset
+	    pyega3 -c 10 -cf $egaCredentialsDir/ega.credentials fetch ${params.EGA_DATASET_ID} --output-dir ega_data --max-retries -1 --retry-wait 10
         """
-    }
 }
 
 process make_metadata_table {
 
-    conda 'r-base r-xml2 r-optparse'
-    
-    errorStrategy 'ignore'
+    conda 'r-base r-xml2 r-optparse r-jsonlite r-dplyr'
 
     cache 'deep'
 
-    publishDir "$metadataDir/$dsId", mode: 'copy', overwrite: true
-
     input:
-        set val(dsId), file(file_listing) from AVAILABLE_FILES
+        val EGA_DATASET_ID
 
     output:
-        file("${dsId}.merged.csv") into DATASET_CSVS
+        file "ega_metadata/${EGA_DATASET_ID}.merged.csv"
 
-    """
-    # Do things slightly differently depending on where the file listing came from
-    param='-y'
-    if [ file_listing = 'dbox_content' ]; then
-        param='-x'
-    fi
-
-    arrange_data.R -m $metadataDir -d $dataDir -i $dsId \$param $file_listing -o ${dsId}.merged.csv
-    """
-}
-
-if (fetchMode == 'aspera'){
-
-    DATASET_CSVS
-        .splitCsv( header:true, sep:"\t" )
-        .map{ row -> tuple(row['file'], row['ega_dataset_id'], row['biosample_id'], row['ega_run_id'], row['library_layout'], row['library_strategy'], row['remote_path'], file(row['remote_path']).getName()) }
-        .set{
-            DOWNLOAD_LIST
-        }
-
-    process get_dbox_files {
-        
-        storeDir "$dataDir/$dsId/encrypted"
-
-        errorStrategy { task.attempt<=3 ? 'retry' : 'ignore' }
-        
-        cache 'lenient'
-        
-        maxForks 10
-     
-        input:
-            set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), val(dboxPath), val(dboxFileName) from DOWNLOAD_LIST
-
-        output:
-            set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(dboxFileName) into ENCRYPTED_LINES
-
+    script:
         """
-        credentialsFile=$egaCredentialsDir/${dsId}.txt
-        if [ ! -e \$credentialsFile ]; then
-            echo "Credentials file missing at \$credentialsFile" 1>&2
-            exit 1
-        fi
-
-        user=\$(grep "^user=" \$credentialsFile | sed s/user=//)
-        password=\$(grep "^password=" \$credentialsFile | sed s/password=//)
-        export ASPERA_SCP_PASS="\$password";   
-     
-        ascp --ignore-host-key -k 1 --partial-file-suffix=PART -QTl 100m \${user}@xfer.crg.eu:$dboxPath \$(pwd)/
+	    mkdir -p ega_metadata
+	    ${workflow.launchDir}/bin/arrange_data.R -m $metadataDir -i ${params.EGA_DATASET_ID} -o ega_metadata/${params.EGA_DATASET_ID}.merged.csv
         """
-    }
-
-    process decrypt {
-        
-        storeDir "$dataDir/$dsId/$libraryStrategy"
-
-        input:
-            set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(encryptedFile) from ENCRYPTED_LINES
-
-        output:
-            set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(fileName) into DECRYPTED_LINES
-
-        """
-        credentialsFile=$egaCredentialsDir/${dsId}.txt
-        if [ ! -e \$credentialsFile ]; then
-            echo "Credentials file missing at \$credentialsFile" 1>&2
-            exit 1
-        fi
-
-        secret=\$(grep "^secret=" \$credentialsFile | sed s/secret=//)
-        echo \$secret > secret.txt
-        java -jar ${workflow.projectDir}/bin/decryptor.jar secret.txt $encryptedFile 
-        """
-    }
-}
-else{
-    
-    DATASET_CSVS
-        .splitCsv( header:true, sep:"\t" )
-        .map{ row -> tuple(row['file'], row['ega_dataset_id'], row['biosample_id'], row['ega_run_id'], row['library_layout'], row['library_strategy'], row['remote_path'], file(row['remote_path']).getName(), row['file_id']) }
-        .set{
-            DOWNLOAD_LIST
-        }
-
-    process get_ega_files {
-        
-        storeDir "$dataDir/$dsId/$libraryStrategy"
-
-        errorStrategy { task.attempt<=3 ? 'retry' : 'ignore' }
-        
-        cache 'lenient'
-
-        conda 'pyega3>=5.2.0 python>=3.9.19'
-        
-        maxForks 10
-     
-        input:
-            set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), val(remotePath), val(remoteFileName), val(fileId) from DOWNLOAD_LIST
-
-        output:
-            set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(fileName) into DECRYPTED_LINES
-
-        """
-        pyega3 -d -cf $egaCredentialsDir/ega.credentials fetch $fileId
-        mv $fileId/$fileName .
-        """
-
-    }
-
 }
 
-DECRYPTED_LINES
-    .into{
-        DECRYPTED_LINES_FOR_CRAMS_BAMS
-        DECRYPTED_LINES_FOR_READMES
-    }
-
-
-DECRYPTED_LINES_FOR_CRAMS_BAMS
-    .filter{ row -> row[0].endsWith('.cram') | row[0].endsWith('.bam') }
-    .set{
-        CRAMS_BAMS_FOR_FASTQS
-    }
-
-process test_endedness {
-
-    conda 'samtools'
-
-    input:
-        set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(cramFile) from CRAMS_BAMS_FOR_FASTQS
-    
-    output:
-        set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(cramFile), stdout into ENDED_CRAMS_BAMS
-   
-    """
-    n_paired_reads=\$(samtools view -c -f 1 $cramFile)
-    if [ \$n_paired_reads = 0 ]; then
-        echo -n SINGLE
-    else
-        echo -n PAIRED
-    fi
-    """ 
-}
-
-PAIRED = Channel.create()
-UNPAIRED = Channel.create()
-
-ENDED_CRAMS_BAMS.choice( UNPAIRED, PAIRED ) {a -> 
-    a[7] == 'PAIRED' ? 1 : 0
-}
-
-// Paired bam to fastq
-
-process paired_cram_bam_to_fastq {
-
-    conda 'samtools'
-    
-    cache 'lenient'
-
-    errorStrategy { task.attempt<=3 ? 'retry' : 'finish' }    
-    memory { 2.GB * task.attempt }
-
-    input:
-        set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(cramFile), val(end) from PAIRED
-
-    output:
-        set val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), val("${cramFile.baseName}"), file("${cramFile.baseName}_1.fastq.gz"), file("${cramFile.baseName}_2.fastq.gz") into FASTQS_FROM_PAIRED
-    
-    """
-    export REF_CACHE=$dataDir/reference
-    samtools collate $cramFile ${cramFile}.collated
-    samtools fastq -F 2816 -c 6 -1 ${cramFile.baseName}_1.fastq.gz -2 ${cramFile.baseName}_2.fastq.gz ${cramFile}.collated.bam
-    """
-}
-
-// Unpaired bam to fastq
-
-process unpaired_cram_bam_to_fastq {
-
-    conda 'samtools'
-    
-    publishDir "$dataDir/$dsId/$libraryStrategy/fastq", mode: 'copy', overwrite: true
-    
-    cache 'lenient'
-
-    errorStrategy { task.attempt<=3 ? 'retry' : 'finish' }    
-    memory { 2.GB * task.attempt }
-
-    input:
-        set val(fileName), val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file(cramFile), val(end) from UNPAIRED
-
-    output:
-        set val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), file("${cramFile.baseName}.fastq.gz") into FASTQS_FROM_UNPAIRED
-    
-    """
-    export REF_CACHE=$dataDir/reference
-    samtools collate $cramFile ${cramFile}.collated
-    samtools fastq -F 2816 -c 6 ${cramFile}.collated.bam > ${cramFile.baseName}.fastq.gz 
-    """
-}
-
-// Synchronise paired-end read files 
-
-process synchronise_pairs {
-  
-    conda 'fastq-pair'
-    
-    publishDir "$dataDir/$dsId/$libraryStrategy/fastq", mode: 'copy', overwrite: true
-  
-    memory { 30.GB * task.attempt }
-
-    errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 || task.attempt < 3 ? 'retry' : 'ignore' }
-    maxRetries 3
-    
-    input:
-        set val(dsId), val(biosampleId), val(egaRunId), val(libraryLayout), val(libraryStrategy), val(baseName), file('read1.fastq.gz'), file('read2.fastq.gz') from FASTQS_FROM_PAIRED
-
-    output:
-        set file( "${baseName}_1.fastq.gz" ), file("${baseName}_2.fastq.gz") into MATCHED_PAIRED_FASTQS
-
-    beforeScript 'mkdir -p matched && mkdir -p unmatched'
-
-    """
-        zcat read1.fastq.gz > read1.fastq
-        zcat read2.fastq.gz > read2.fastq
-        fastq_pair read1.fastq read2.fastq
-
-        gzip read1.fastq.paired.fq && mv read1.fastq.paired.fq.gz ${baseName}_1.fastq.gz
-        gzip read2.fastq.paired.fq && mv read2.fastq.paired.fq.gz ${baseName}_2.fastq.gz
-
-        rm -f read1.fastq read2.fastq
-    """          
-}
-
-DECRYPTED_LINES_FOR_READMES
-    .map{ row -> row[1] }
-    .unique()
-    .set{
-        FINAL_DATASETS
-    }
-
-process add_readme {
-
-    publishDir "$dataDir/$dsId", mode: 'copy', overwrite: true
-    
-    input:
-        val(dsId) from FINAL_DATASETS
-    
-    output:
-        file('README.md')
-
-    """
-    user=\$(whoami)
-    pushd ${workflow.projectDir}
-    remote=\$(git remote -v | head -n 1 | awk '{print \$2}')
-    sha=\$(git rev-parse --verify HEAD)
-    popd
-
-    cp ${workflow.projectDir}/template_readme.md README.md
-    sed -i "s/USER/\$user/g" README.md 
-    sed -i "s#REMOTE#\$remote#g" README.md 
-    sed -i "s/COMMIT/\$sha/g" README.md 
-    """
-}

--- a/main.nf
+++ b/main.nf
@@ -41,7 +41,7 @@ else{
     process get_ega_file_listing {
 
         // This process is not strictly necessary, but it is useful to have a cached file listing.
-        // Current versipn pf pyega3 can be provided directly with the dataset ID (EGAD*) and this will
+        // Current version pf pyega3 can be provided directly with the dataset ID (EGAD*) and this will
         // directly download all relevant files without the need of storing them into a txt file
         
         cache 'lenient'
@@ -82,8 +82,8 @@ process make_metadata_table {
     if [ file_listing = 'dbox_content' ]; then
         param='-x'
     fi
-    
-    arrange_data.R -m $metadataDir -d $dataDir -i $dsId \$param $file_listing -o ${dsId}.merged.csv 
+
+    arrange_data.R -m $metadataDir -d $dataDir -i $dsId \$param $file_listing -o ${dsId}.merged.csv
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -25,9 +25,9 @@ process fetch_data {
         """
         mkdir -p ega_data
         # list unencrypted md5 checksums for all files
-        pyega3 -cf $egaCredentialsDir/ega.credentials files ${params.EGA_DATASET_ID}
+        pyega3 -cf $egaCredentialsDir/ega.credentials files $EGA_DATASET_ID
         # download the dataset
-        pyega3 -c 10 -cf $egaCredentialsDir/ega.credentials fetch ${params.EGA_DATASET_ID} --output-dir ega_data --max-retries -1 --retry-wait 10
+        pyega3 -c 10 -cf $egaCredentialsDir/ega.credentials fetch $EGA_DATASET_ID --output-dir ega_data --max-retries -1 --retry-wait 10
         """
 }
 
@@ -46,7 +46,7 @@ process make_metadata_table {
     script:
         """
         mkdir -p ega_metadata
-        ${workflow.launchDir}/bin/arrange_data.R -m $metadataDir -i ${params.EGA_DATASET_ID} -o ega_metadata/${params.EGA_DATASET_ID}.merged.csv
+        ${workflow.launchDir}/bin/arrange_data.R -m $metadataDir -i $EGA_DATASET_ID -o ega_metadata/${EGA_DATASET_ID}.merged.csv
         """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -23,11 +23,11 @@ process fetch_data {
 
     script:
         """
-	    mkdir -p ega_data
-	    # list unencrypted md5 checksums for all files
-	    pyega3 -cf $egaCredentialsDir/ega.credentials files ${params.EGA_DATASET_ID}
-	    # download the dataset
-	    pyega3 -c 10 -cf $egaCredentialsDir/ega.credentials fetch ${params.EGA_DATASET_ID} --output-dir ega_data --max-retries -1 --retry-wait 10
+        mkdir -p ega_data
+        # list unencrypted md5 checksums for all files
+        pyega3 -cf $egaCredentialsDir/ega.credentials files ${params.EGA_DATASET_ID}
+        # download the dataset
+        pyega3 -c 10 -cf $egaCredentialsDir/ega.credentials fetch ${params.EGA_DATASET_ID} --output-dir ega_data --max-retries -1 --retry-wait 10
         """
 }
 
@@ -45,8 +45,8 @@ process make_metadata_table {
 
     script:
         """
-	    mkdir -p ega_metadata
-	    ${workflow.launchDir}/bin/arrange_data.R -m $metadataDir -i ${params.EGA_DATASET_ID} -o ega_metadata/${params.EGA_DATASET_ID}.merged.csv
+        mkdir -p ega_metadata
+        ${workflow.launchDir}/bin/arrange_data.R -m $metadataDir -i ${params.EGA_DATASET_ID} -o ega_metadata/${params.EGA_DATASET_ID}.merged.csv
         """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,13 +5,15 @@ params {
 }
 
 process {
-    executor='lsf'
-    queue='production-rh74'
+    executor='slurm'
+    queue='production'
 }
 
 executor {
     queueSize=500
-    perJobMemLimit=true
+    # perJobMemLimit=true # only for lsf
     exitReadTimeout='100000 sec'
     pollInterval = '5sec'
+    memory = '4 GB'
+    time = '1d'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,19 +1,31 @@
 params {
-    dataDir = 'data'
+    EGA_DATASET_ID = 'EGAD00001011134' // default value, can be overridden when running the workflow
     metadataDir = 'metadata'
     egaCredentialsDir = 'credentials'
 }
 
-process {
-    executor='slurm'
-    queue='production'
+conda {
+    enabled = true
+    cacheDir = "$CONDA_ENVS"
+    createTimeout = "2 h"
+    useMamba = true
 }
 
-executor {
-    queueSize=500
-    # perJobMemLimit=true # only for lsf
-    exitReadTimeout='100000 sec'
-    pollInterval = '5sec'
+process {
+    executor = 'slurm'
+    queue = 'production'
+    cpus = 1
     memory = '4 GB'
-    time = '1d'
+    time = '167h'
+    queueSize = 500
+    submitRateLimit = "10/1sec"
+    exitReadTimeout = '100000 sec'
+    pollInterval = '5sec'
+    jobName = {
+        task.name // [] and " " not allowed in lsf job names
+            .replace("[", "(")
+            .replace("]", ")")
+            .replace(" ", "_")
+    }
 }
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 params {
-    EGA_DATASET_ID = 'EGAD00001011134' // default value, can be overridden when running the workflow
+    EGA_DATASET_ID = 'EGAD00001011134'
     metadataDir = 'metadata'
     egaCredentialsDir = 'credentials'
 }

--- a/template_readme.md
+++ b/template_readme.md
@@ -1,1 +1,0 @@
-Data in this directory were downloaded from the EGA by user USER using a custom Nextflow workflow from REMOTE with commit COMMIT. You should see it checked out at ../ega_downloader.  


### PR DESCRIPTION
After some changes  in EGA and pyega3, and in our infrastructure, this workflow requires substantial changes to adapt and simplify the process:

- [x] Migrate executor from LSF to SLURM
- [x] There is no need to decrypt data files downloaded through the pyEGA3 download client. Download comes on fastq format
- [x] Pin latest version of `pyega3`
- [x] It seems to be possible to download data in Fastq directly, thus avoiding the bam-to-fastq conversion
- [x] Metadata downloads have also changed from XML+mapping files [to files in tsv/csv/json format ](https://ega-archive.org/access/download/metadata/#DatasetMappings). Changes in bin/arrange_data.R for the goal of retrieving the final `EGADXXXXXX.merged.tsv`
- [x] Migrate from DSL1 to DSL2
- [x] Deprecate Aspera fetching mode
- [x] Enable Seqera platform (for logging and monitoring)
- [x] Update README
